### PR TITLE
v0.2.1: use tikzset

### DIFF
--- a/annotate-equations.sty
+++ b/annotate-equations.sty
@@ -5,7 +5,7 @@
 % 
 \NeedsTeXFormat{LaTeX2e}[1994/06/01]
 \ProvidesPackage{annotate-equations}
-  [2023/02/15 v0.2.0 easily annotate equations using TikZ]
+  [2023/03/05 v0.2.1 easily annotate equations using TikZ]
 
 %%% lualatex compatibility, from https://tex.stackexchange.com/a/351520/171664
 \RequirePackage{ifluatex}
@@ -54,6 +54,9 @@
     label above/.code = {\renewcommand\EAlabelanchor{south}},
     label below/.code = {\renewcommand\EAlabelanchor{north}},
 }
+
+\tikzset{annotate equations/arrow/.style={}}
+\tikzset{annotate equations/text/.style={font=\eqnannotationfont}}
 
 %%%%% %%%%%%%% %%%%%
 
@@ -128,13 +131,13 @@
     \begin{tikzpicture}[overlay,remember picture,>=stealth,nodes={align=left,inner ysep=1pt},<-]
         % default anchor is at center
 		\node[anchor=\swapNorthSouth{\EAmarkanchor},color=\myEAcolor!85,
-			font=\eqnannotationfont,#1
+			annotate equations/text,#1
 			]  % color blended with white to 85%, any (optional) extra args #1
             (\eqnannotateCurrentNode)   % use counter-based "local node"
             at ($(\myEAmarkOne.\EAmarkanchor)!0.5!(\myEAmarkTwo.\EAmarkanchor)$)  % centered between the two nodes
             {\myEAtext\eqnannotationstrut};
         % double arrow to two uses within the equation:
-        \draw [<->,color=\myEAcolor] (\myEAmarkOne.\EAmarkanchor) |- ([yshift=0.1ex] \eqnannotateCurrentNode.\EAlabelanchor) -| (\myEAmarkTwo.\EAmarkanchor);  % from node 1 via annotation to node 2, with anchor #6 each
+        \draw [<->,color=\myEAcolor, annotate equations/arrow] (\myEAmarkOne.\EAmarkanchor) |- ([yshift=0.1ex] \eqnannotateCurrentNode.\EAlabelanchor) -| (\myEAmarkTwo.\EAmarkanchor);  % from node 1 via annotation to node 2, with anchor #6 each
     \end{tikzpicture}%
     \endgroup% %%% close group again
 }
@@ -171,13 +174,13 @@
     \def\myEAxshift{\EAxshift{\EAwesteast}}%
     \begin{tikzpicture}[overlay,remember picture,>=stealth,nodes={align=left,inner ysep=1pt},<-]
 		\node[anchor=\swapNorthSouth{\EAmarkanchor} \swapWestEast{\EAwesteast},
-			color=\myEAcolor!85,font=\eqnannotationfont,#1] % TODO for some reason, passing #1 through command doesn't work...
+			color=\myEAcolor!85,annotate equations/text,#1] % TODO for some reason, passing #1 through command doesn't work...
                 % anchor=west: align left edge of text on top of tikzmark in equation
                 % should be north west for below and south west for above ...
             (\eqnannotateCurrentNode) at (\myEAmark.\EAmarkanchor)  % \EAmarkanchor north: above the equation, south: below
             {\myEAtext\eqnannotationstrut};
         \foreach \EAmark in \myEAmarks
-        \draw [color=\myEAcolor] (\EAmark.\EAmarkanchor)  % arrow from the equation
+        \draw [color=\myEAcolor, annotate equations/arrow] (\EAmark.\EAmarkanchor)  % arrow from the equation
                 % \EAmarkanchor north: above the equation, south: below
             |- ([xshift=\myEAxshift,yshift=0.1ex] \eqnannotateCurrentNode.south \EAwesteast);
                 % - south east: we want line to end at bottom right of annotation text;

--- a/annotate-equations.tex
+++ b/annotate-equations.tex
@@ -26,7 +26,7 @@
   text above listing,
   #1}
 
-\title{\texttt{annotate-equations.sty}}
+\title{\texttt{annotate-equations.sty}, v.0.2.1}
 \author{ST John}
 \date{\url{https://github.com/st--/annotate-equations}}
 
@@ -256,6 +256,18 @@ By redefining this command, you can change the ``alpha'' value of the highlight:
 \vspace{1em}
 \end{LTXexample}
 \noindent
+%
+Alternatively, you can also change the style of \verb|annotate equations/text|:
+\begin{LTXexample}[text outside listing,lefthand width=0.5in]
+\tikzset{annotate equations/text/.style={font=\bfseries\small}}
+
+\begin{equation*}
+    \eqnmarkbox[blue]{v}{v}
+\end{equation*}
+\annotate[yshift=-0.5em]{below}{v}{velocity}
+\vspace{1em}
+\end{LTXexample}
+\noindent
 
 \verb|\eqnannotationstrut| is defined to be a strut (zero-width height) to
 provide minimum distance between the text and the corresponding arrow line. By
@@ -283,6 +295,32 @@ default it is \verb|\strut|, which has a similar effect to
 \vspace{1em}
 \end{LTXexample}
 
+
+\subsection{Customize style}
+
+You can change the style of the annotation arrow line by setting the style of \verb|annotate equations/arrow|:
+\begin{LTXexample}[text outside listing,lefthand width=0.5in]
+\tikzset{annotate equations/arrow/.style={color=ForestGreen, >=latex', very thick, dashed}}
+
+\begin{equation*}
+  \eqnmarkbox[blue]{size}{s} = \eqnmarkbox[red]{other}{x}
+\end{equation*}
+\annotate[yshift=-0.5em]{below}{size}{The size}
+\annotatetwo[yshift=1em]{above}{size}{other}{the same}
+\end{LTXexample}
+\noindent
+Note that it applies to all \verb|\annotate| and \verb|\annotatetwo| arrows within the scope.
+
+You can also use this to change the arrow direction:
+\begin{LTXexample}[text outside listing,lefthand width=0.5in]
+\begin{equation*}
+  \eqnmarkbox[blue]{size}{s} = \eqnmarkbox[red]{other}{x}
+\end{equation*}
+\tikzset{annotate equations/arrow/.style={->}}
+\annotatetwo[yshift=1em]{above}{size}{other}{one and}
+\tikzset{annotate equations/arrow/.style={<-}}
+\annotatetwo[yshift=-1em]{below, label below}{size}{other}{the same}  % note that the "direction" of the arrow is from first to second mark
+\end{LTXexample}
 
 \section{Recommendations, tips \& tricks}
 


### PR DESCRIPTION
I just realized that pgfkeys/`\tikzset` makes it very easy to allow customization of the style of both arrows and text. This PR adds new paths `annotate equations/arrow` and `annotate equations/text` that can change the style of arrow path and text node, respectively, using for example `\tikzset{annotate equations/arrow/.style={dotted}}` for a dotted annotation line. Resolves #14 :)